### PR TITLE
Add new tokenier alias for llmev

### DIFF
--- a/elm/base.py
+++ b/elm/base.py
@@ -45,7 +45,8 @@ class ApiBase(ABC):
     """High level model role"""
 
     TOKENIZER_ALIASES = {'gpt-35-turbo': 'gpt-3.5-turbo',
-                         'gpt-4-32k': 'gpt-4-32k-0314'
+                         'gpt-4-32k': 'gpt-4-32k-0314',
+                         'llmev-gpt-4-32k': 'gpt-4-32k-0314'
                          }
     """Optional mappings for unusual Azure names to tiktoken/openai names."""
 


### PR DESCRIPTION
Added a new tokenizer alias for the llmev OpenAI endpoint: llmev-gpt-4-32k. I tested this using examples/ordinance_gpt for a couple counties and it seems to be working as expected. Here is the last line from log file, 'Jeferson County, Colorado.log':
4 ordinance value(s) found for Jefferson County, Colorado. Outputs are here: 'county_dbs/Jefferson County, Colorado Ordinances.csv'