### PR TITLE
Fix scraping on Unix systems

### DIFF
--- a/elm/cli.py
+++ b/elm/cli.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# fmt: off
 """ELM Ordinances CLI."""
 import sys
 import json
 import click
 import asyncio
 import logging
+import multiprocessing
 
 from elm.version import __version__
 from elm.ords.process import process_counties_with_openai
@@ -36,6 +36,12 @@ def ords(config, verbose):
         logger = logging.getLogger("elm")
         logger.addHandler(logging.StreamHandler(stream=sys.stdout))
         logger.setLevel(config.get("log_level", "INFO"))
+
+    # Need to set start method to "spawn" instead of "fork" for unix
+    # systems. If this call is not present, software hangs when process
+    # pool executor is launched.
+    # More info here: https://stackoverflow.com/a/63897175/20650649
+    multiprocessing.set_start_method('spawn')
 
     # asyncio.run(...) doesn't throw exceptions correctly for some reason...
     loop = asyncio.get_event_loop()

--- a/elm/web/google_search.py
+++ b/elm/web/google_search.py
@@ -274,7 +274,7 @@ async def _load_docs(urls, browser_semaphore=None, **kwargs):
     docs = await file_loader.fetch_all(*urls)
 
     logger.debug(
-        "Loaded the following number of pages for docs: %s",
+        "Loaded the following number of pages for docs:\n%s",
         pprint.PrettyPrinter().pformat(
             {
                 doc.metadata.get("source", "Unknown"): len(doc.pages)


### PR DESCRIPTION
Fix a particularly nasty bug that caused scraping to seemingly "hang" when running on Unix systems. This was being caused by a failure of async sephamores when processes are forked. Fix this issues by spawning processes instead of forking. This is the default way to spawn processes on Windows, which is why this issue went undetected previously