### PR TITLE
Playwright timeout workarounds

### DIFF
--- a/.github/workflows/pytest_ords.yml
+++ b/.github/workflows/pytest_ords.yml
@@ -44,7 +44,7 @@ jobs:
         python -m pip install psycopg2-binary
         python -m pip install boto3
         python -m pip install .
-        playwright install
+        rebrowser_playwright install
     - name: Run pytest and Generate coverage report
       shell: bash -l {0}
       run: |

--- a/elm/ords/README.md
+++ b/elm/ords/README.md
@@ -23,7 +23,7 @@ At this point, you can install ELM per the [front-page README](https://github.co
 After ELM installs successfully, you must instantiate the playwright module, which is used for web scraping.
 To do so, simply run:
 
-    $ playwright install
+    $ rebrowser_playwright install
 
 Now you are ready to run ordinance retrieval and extraction. See the [example](https://github.com/NREL/elm/blob/main/examples/ordinance_gpt/README.rst) to get started. If you get additional import errors, just install additional packages as necessary, e.g.:
 

--- a/elm/web/file_loader.py
+++ b/elm/web/file_loader.py
@@ -9,6 +9,7 @@ from fake_useragent import UserAgent
 from elm.utilities.parse import read_pdf
 from elm.web.document import PDFDocument, HTMLDocument
 from elm.web.html_pw import load_html_with_pw
+from elm.web.utilities import DEFAULT_HEADERS
 from elm.utilities.retry import async_retry_with_exponential_backoff
 from elm.exceptions import ELMRuntimeError
 
@@ -44,20 +45,6 @@ class AsyncFileLoader:
     .. end desc
     """
 
-    DEFAULT_HEADER_TEMPLATE = {
-        "User-Agent": "",
-        "Accept": (
-            "text/html,application/xhtml+xml,application/xml;"
-            "q=0.9,image/webp,*/*;q=0.8"
-        ),
-        "Accept-Language": "en-US,en;q=0.5",
-        "Referer": "https://www.google.com/",
-        "DNT": "1",
-        "Connection": "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-    }
-    """Default header"""
-
     PAGE_LOAD_TIMEOUT = 90_000
     """Default page load timeout value in milliseconds"""
 
@@ -80,8 +67,8 @@ class AsyncFileLoader:
         Parameters
         ----------
         header_template : dict, optional
-            Optional GET header template. If not specified, uses the
-            `DEFAULT_HEADER_TEMPLATE` defined for this class.
+            Optional GET header template. If not specified, uses
+            :obj:`~elm.web.utilities.DEFAULT_HEADERS`.
             By default, ``None``.
         verify_ssl : bool, optional
             Option to use aiohttp's default SSL check. If ``False``,
@@ -146,10 +133,11 @@ class AsyncFileLoader:
 
     def _header_from_template(self, header_template):
         """Compile header from user or default template"""
-        headers = header_template or self.DEFAULT_HEADER_TEMPLATE
+        headers = header_template or DEFAULT_HEADERS
+        headers = dict(headers)
         if not headers.get("User-Agent"):
             headers["User-Agent"] = UserAgent().random
-        return dict(headers)
+        return headers
 
     async def fetch_all(self, *urls):
         """Fetch documents for all requested URL's.

--- a/elm/web/google_search.py
+++ b/elm/web/google_search.py
@@ -10,6 +10,7 @@ from playwright.async_api import (
     async_playwright,
     TimeoutError as PlaywrightTimeoutError,
 )
+from playwright_stealth import stealth_async
 
 from elm.web.document import PDFDocument
 from elm.web.file_loader import AsyncFileLoader
@@ -73,6 +74,7 @@ class PlaywrightGoogleLinkSearch:
 
         logger.trace("Loading browser page for query: %r", query)
         page = await self._browser.new_page()
+        await stealth_async(page)
         logger.trace("Navigating to google for query: %r", query)
         await _navigate_to_google(page, timeout=self.PAGE_LOAD_TIMEOUT)
         logger.trace("Performing google search for query: %r", query)

--- a/elm/web/google_search.py
+++ b/elm/web/google_search.py
@@ -6,7 +6,7 @@ import logging
 from itertools import zip_longest, chain
 from contextlib import AsyncExitStack
 
-from playwright.async_api import (
+from rebrowser_playwright.async_api import (
     async_playwright,
     TimeoutError as PlaywrightTimeoutError,
 )

--- a/elm/web/html_pw.py
+++ b/elm/web/html_pw.py
@@ -9,6 +9,7 @@ from contextlib import AsyncExitStack
 from playwright.async_api import async_playwright
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from playwright_stealth import stealth_async
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,7 @@ async def _load_html(  # pragma: no cover
         browser = await p.chromium.launch(**pw_launch_kwargs)
         logger.trace("Loading new page")
         page = await browser.new_page()
+        await stealth_async(page)
         logger.trace("Intercepting requests and aborting blocked ones")
         await page.route("**/*", _intercept_route)
         logger.trace("Navigating to: %r", url)

--- a/elm/web/html_pw.py
+++ b/elm/web/html_pw.py
@@ -13,53 +13,10 @@ from rebrowser_playwright.async_api import (
 )
 from playwright_stealth import stealth_async
 
+from elm.web.utilities import pw_page
+
+
 logger = logging.getLogger(__name__)
-
-# block pages by resource type. e.g. image, stylesheet
-BLOCK_RESOURCE_TYPES = [
-    "beacon",
-    "csp_report",
-    "font",
-    "image",
-    "imageset",
-    "media",
-    "object",
-    "texttrack",
-    #  can block stylsheets and scripts, though it's not recommended:
-    # 'stylesheet',
-    # 'script',
-    # 'xhr',
-]
-
-
-# block popular 3rd party resources like tracking and advertisements.
-BLOCK_RESOURCE_NAMES = [
-    "adzerk",
-    "analytics",
-    "cdn.api.twitter",
-    "doubleclick",
-    "exelator",
-    "facebook",
-    "fontawesome",
-    "google",
-    "google-analytics",
-    "googletagmanager",
-    "lit.connatix",  # <- not sure about this one
-]
-
-
-async def _intercept_route(route):  # pragma: no cover
-    """intercept all requests and abort blocked ones
-
-    Source: https://scrapfly.io/blog/how-to-block-resources-in-playwright/
-    """
-    if route.request.resource_type in BLOCK_RESOURCE_TYPES:
-        return await route.abort()
-
-    if any(key in route.request.url for key in BLOCK_RESOURCE_NAMES):
-        return await route.abort()
-
-    return await route.continue_()
 
 
 async def load_html_with_pw(  # pragma: no cover
@@ -111,15 +68,11 @@ async def _load_html(  # pragma: no cover
         logger.trace("launching chromium; browser_semaphore=%r",
                      browser_semaphore)
         browser = await p.chromium.launch(**pw_launch_kwargs)
-        logger.trace("Loading new page")
-        page = await browser.new_page()
-        await stealth_async(page)
-        logger.trace("Intercepting requests and aborting blocked ones")
-        await page.route("**/*", _intercept_route)
-        logger.trace("Navigating to: %r", url)
-        await page.goto(url)
-        logger.trace("Waiting for load with timeout: %r", timeout)
-        await page.wait_for_load_state("networkidle", timeout=timeout)
-        text = await page.content()
+        async with pw_page(browser, intercept_routes=True) as page:
+            logger.trace("Navigating to: %r", url)
+            await page.goto(url)
+            logger.trace("Waiting for load with timeout: %r", timeout)
+            await page.wait_for_load_state("networkidle", timeout=timeout)
+            text = await page.content()
 
     return text

--- a/elm/web/html_pw.py
+++ b/elm/web/html_pw.py
@@ -11,7 +11,6 @@ from rebrowser_playwright.async_api import Error as PlaywrightError
 from rebrowser_playwright.async_api import (
     TimeoutError as PlaywrightTimeoutError
 )
-from playwright_stealth import stealth_async
 
 from elm.web.utilities import pw_page
 

--- a/elm/web/html_pw.py
+++ b/elm/web/html_pw.py
@@ -6,9 +6,11 @@ We use Playwright so that javascript text is rendered before we scrape.
 import logging
 from contextlib import AsyncExitStack
 
-from playwright.async_api import async_playwright
-from playwright.async_api import Error as PlaywrightError
-from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from rebrowser_playwright.async_api import async_playwright
+from rebrowser_playwright.async_api import Error as PlaywrightError
+from rebrowser_playwright.async_api import (
+    TimeoutError as PlaywrightTimeoutError
+)
 from playwright_stealth import stealth_async
 
 logger = logging.getLogger(__name__)

--- a/elm/web/utilities.py
+++ b/elm/web/utilities.py
@@ -24,7 +24,7 @@ DEFAULT_HEADERS = {
     "Upgrade-Insecure-Requests": "1",
 }
 """Default HTML header template"""
-_BT_RENAME = {"chromium": "chrome"}
+_BT_RENAME = {"chromium": "Chrome"}
 # block pages by resource type. e.g. image, stylesheet
 BLOCK_RESOURCE_TYPES = [
     "beacon",
@@ -182,8 +182,7 @@ async def pw_page(browser, intercept_routes=False):
     :class:`playwright.Page`
         A new page that can be used for visiting websites.
     """
-    browser_type = browser.browser_type.name
-    browser_type = _BT_RENAME.get(browser_type, browser_type)
+    browser_type = _BT_RENAME.get(browser.browser_type.name, "random")
 
     logger.trace("Loading browser context for browser type %s", browser_type)
     context = await browser.new_context(

--- a/elm/web/utilities.py
+++ b/elm/web/utilities.py
@@ -6,6 +6,19 @@ from pathlib import Path
 
 from slugify import slugify
 
+DEFAULT_HEADERS = {
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;"
+        "q=0.9,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.5",
+    "Referer": "https://www.google.com/",
+    "DNT": "1",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+}
+"""Default HTML header template"""
+
 
 def clean_search_query(query):
     """Check if the first character is a digit and remove it if so.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ nltk
 numpy
 pandas
 playwright
+playwright-stealth
 PyPDF2
 python-slugify
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openai>=1.1.0
 aiohttp
 click
-fake_useragent
+fake_useragent>=2.0.3
 html2text
 langchain
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ nrel-rex
 nltk
 numpy
 pandas
-playwright
+rebrowser-playwright
 playwright-stealth
 PyPDF2
 python-slugify

--- a/tests/web/test_web_google_search.py
+++ b/tests/web/test_web_google_search.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 
 import pytest
-from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from rebrowser_playwright.async_api import (
+    TimeoutError as PlaywrightTimeoutError
+)
 
 import elm.web.google_search
 


### PR DESCRIPTION
Add a combination of changes designed to work around recent timeout errors seen in playwright. Note that this workaround is not perfect and may break down in the future. Likely the correct long-term fix is to add fallback options like a custom google search engine or the use of another SE altogether like duckduckgo. I plan to add these fallback options in upcoming PR's.