### PR TITLE
Add fallback options to search

### DIFF
--- a/docs/source/dev/ords_architecture.rst
+++ b/docs/source/dev/ords_architecture.rst
@@ -760,7 +760,7 @@ We give a rough breakdown of the following call:
 .. code-block:: python
 
     import asyncio
-    from elm.web.google_search import google_results_as_docs
+    from elm.web.search import web_search_links_as_docs
 
     QUERIES = [
         "NREL wiki",
@@ -769,7 +769,7 @@ We give a rough breakdown of the following call:
     ]
 
     async def main():
-        docs = await google_results_as_docs(QUERIES, num_urls=4)
+        docs = await web_search_links_as_docs(QUERIES, num_urls=4)
         return docs
 
     if __name__ == "__main__":
@@ -778,7 +778,7 @@ We give a rough breakdown of the following call:
 
 **Step-by-Step:**
 
-1. :func:`~elm.web.google_search.google_results_as_docs()` is invoked with 3 queries and ``num_urls=4``.
+1. :func:`~elm.web.search.run.web_search_links_as_docs()` is invoked with 3 queries and ``num_urls=4``.
 2. Each of the three queries are processed asynchronously, creating a :class:`~elm.web.google_search.PlaywrightGoogleLinkSearch` instance and retrieving the top URL results.
 3. Internal code reduces the URL lists returned from each of the queries into the top 4 URLs.
 4. :class:`~elm.web.file_loader.AsyncFileLoader` asynchronously downloads the content for reach of the top 4 URLs, determines the document type the content should be stored
@@ -789,7 +789,7 @@ We give a rough breakdown of the following call:
 .. mermaid::
 
     sequenceDiagram
-        participant A as google_results_as_docs()
+        participant A as web_search_links_as_docs()
         participant B as PlaywrightGoogleLinkSearch
         participant D as AsyncFileLoader
         participant E as HTMLDocument

--- a/elm/exceptions.py
+++ b/elm/exceptions.py
@@ -6,5 +6,13 @@ class ELMError(Exception):
     """Generic ELM Error."""
 
 
+class ELMKeyError(ELMError, KeyError):
+    """ELM Key Error."""
+
+
+class ELMInputError(ELMError, ValueError):
+    """ELM Input (Value) Error."""
+
+
 class ELMRuntimeError(ELMError, RuntimeError):
     """ELM RuntimeError."""

--- a/elm/ords/download.py
+++ b/elm/ords/download.py
@@ -7,7 +7,7 @@ from elm.ords.extraction import check_for_ordinance_info
 from elm.ords.services.threaded import TempFileCache
 from elm.ords.validation.location import CountyValidator
 from elm.web.document import PDFDocument
-from elm.web.search.google import google_results_as_docs
+from elm.web.search import web_search_links_as_docs
 from elm.web.utilities import filter_documents
 
 
@@ -101,7 +101,7 @@ async def _docs_from_google_search(
             "file_cache_coroutine": TempFileCache.call,
         }
     )
-    return await google_results_as_docs(
+    return await web_search_links_as_docs(
         queries,
         num_urls=num_urls,
         browser_semaphore=browser_semaphore,

--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/elm/web/file_loader.py
+++ b/elm/web/file_loader.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 async def _read_pdf_doc(pdf_bytes, **kwargs):
     """Default read PDF function (runs in main thread)"""
-    pages = read_pdf(pdf_bytes)
+    verbose = kwargs.pop("verbose", True)
+    pages = read_pdf(pdf_bytes, verbose=verbose)
     return PDFDocument(pages, **kwargs)
 
 

--- a/elm/web/search/__init__.py
+++ b/elm/web/search/__init__.py
@@ -1,0 +1,3 @@
+"""ELM web search functions"""
+
+from .run import web_search_links_as_docs

--- a/elm/web/search/base.py
+++ b/elm/web/search/base.py
@@ -154,6 +154,11 @@ class PlaywrightSearchEngineLinkSearch(SearchEngineLinkSearch):
     async def _extract_links(self, page, num_results):
         """Extract links for top `num_results` on page"""
         links = await asyncio.to_thread(page.locator, self._SE_SR_TAG)
+
+        if not self.launch_kwargs.get("headless", True):
+            # Viz purposes only
+            [await links.nth(i).hover() for i in range(num_results)]
+
         return [await links.nth(i).get_attribute("href")
                 for i in range(num_results)]
 

--- a/elm/web/search/google.py
+++ b/elm/web/search/google.py
@@ -8,8 +8,7 @@ import requests
 
 from apiclient.discovery import build
 from rebrowser_playwright.async_api import (
-    TimeoutError as PlaywrightTimeoutError
-)
+    TimeoutError as PlaywrightTimeoutError)
 
 from elm.web.search.base import (PlaywrightSearchEngineLinkSearch,
                                  APISearchEngineLinkSearch)

--- a/elm/web/search/google.py
+++ b/elm/web/search/google.py
@@ -2,19 +2,15 @@
 """ELM Web Scraping - Google search."""
 import os
 import json
-import pprint
 import asyncio
 import logging
 import requests
-from itertools import zip_longest, chain
-from contextlib import AsyncExitStack
 
 from apiclient.discovery import build
 from rebrowser_playwright.async_api import (
     TimeoutError as PlaywrightTimeoutError
 )
 
-from elm.web.file_loader import AsyncFileLoader
 from elm.web.search.base import (PlaywrightSearchEngineLinkSearch,
                                  APISearchEngineLinkSearch)
 
@@ -184,121 +180,3 @@ class APISerperSearch(APISearchEngineLinkSearch):
         results = json.loads(response.text).get('organic', {})
         return list(filter(None, (result.get("link", "").replace("+", "%20")
                                   for result in results)))
-
-
-async def google_results_as_docs(
-    queries,
-    num_urls=None,
-    browser_semaphore=None,
-    task_name=None,
-    **file_loader_kwargs,
-):
-    """Retrieve top ``N`` google search results as document instances.
-
-    Parameters
-    ----------
-    queries : collection of str
-        Collection of strings representing google queries. Documents for
-        the top `num_urls` google search results (from all of these
-        queries _combined_ will be returned from this function.
-    num_urls : int, optional
-        Number of unique top Google search result to return as docs. The
-        google search results from all queries are interleaved and the
-        top `num_urls` unique URL's are downloaded as docs. If this
-        number is less than ``len(queries)``, some of your queries may
-        not contribute to the final output. By default, ``None``, which
-        sets ``num_urls = 3 * len(queries)``.
-    browser_semaphore : :class:`asyncio.Semaphore`, optional
-        Semaphore instance that can be used to limit the number of
-        playwright browsers open concurrently. If ``None``, no limits
-        are applied. By default, ``None``.
-    task_name : str, optional
-        Optional task name to use in :func:`asyncio.create_task`.
-        By default, ``None``.
-    **file_loader_kwargs
-        Keyword-argument pairs to initialize
-        :class:`elm.web.file_loader.AsyncFileLoader` with. If found, the
-        "pw_launch_kwargs" key in these will also be used to initialize
-        the :class:`elm.web.google_search.PlaywrightGoogleLinkSearch`
-        used for the google URL search. By default, ``None``.
-
-    Returns
-    -------
-    list of :class:`elm.web.document.BaseDocument`
-        List of documents representing the top `num_urls` results from
-        the google searches across all `queries`.
-    """
-    pw_launch_kwargs = file_loader_kwargs.get("pw_launch_kwargs", {})
-    urls = await _find_urls(
-        queries,
-        num_results=10,
-        browser_sem=browser_semaphore,
-        task_name=task_name,
-        **pw_launch_kwargs
-    )
-    num_urls = num_urls or 3 * len(queries)
-    urls = _down_select_urls(urls, num_urls=num_urls)
-    logger.debug("Downloading documents for URLS: \n\t-%s", "\n\t-".join(urls))
-    docs = await _load_docs(urls, browser_semaphore, **file_loader_kwargs)
-    return docs
-
-
-async def _find_urls(
-    queries, num_results=10, browser_sem=None, task_name=None, **kwargs
-):
-    """Parse google search output for URLs."""
-    searchers = [
-        asyncio.create_task(
-            _search_single(
-                query, browser_sem, num_results=num_results, **kwargs
-            ),
-            name=task_name,
-        )
-        for query in queries
-    ]
-    return await asyncio.gather(*searchers)
-
-
-async def _search_single(question, browser_sem, num_results=10, **kwargs):
-    """Perform a single google search."""
-    if browser_sem is None:
-        browser_sem = AsyncExitStack()
-
-    search_engine = PlaywrightGoogleLinkSearch(**kwargs)
-    logger.trace("Single search browser_semaphore=%r", browser_sem)
-    async with browser_sem:
-        logger.trace("Starting search for %r with browser_semaphore=%r",
-                     question, browser_sem)
-        return await search_engine.results(question, num_results=num_results)
-
-
-def _down_select_urls(search_results, num_urls=5):
-    """Select the top 5 URLs."""
-    all_urls = chain.from_iterable(
-        zip_longest(*[results[0] for results in search_results])
-    )
-    urls = set()
-    for url in all_urls:
-        if not url:
-            continue
-        urls.add(url)
-        if len(urls) == num_urls:
-            break
-    return urls
-
-
-async def _load_docs(urls, browser_semaphore=None, **kwargs):
-    """Load a document for each input URL."""
-    logger.trace("Downloading docs for the following URL's:\n%r", urls)
-    logger.trace("kwargs for AsyncFileLoader:\n%s",
-                 pprint.PrettyPrinter().pformat(kwargs))
-    file_loader = AsyncFileLoader(
-        browser_semaphore=browser_semaphore, **kwargs
-    )
-    docs = await file_loader.fetch_all(*urls)
-
-    page_lens = {doc.metadata.get("source", "Unknown"): len(doc.pages)
-                 for doc in docs}
-    logger.debug("Loaded the following number of pages for docs:\n%s",
-                 pprint.PrettyPrinter().pformat(page_lens))
-    return [doc for doc in docs if not doc.empty]

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -116,7 +116,7 @@ async def _search_with_fallback(search_engines, queries, num_urls,
         raise ELMInputError(msg)
 
     for se_name in search_engines:
-        logger.trace("Searching web using %r", se_name)
+        logger.debug("Searching web using %r", se_name)
         urls = await _single_se_search(se_name, queries, num_urls,
                                        browser_sem, task_name, kwargs)
         if urls:

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -45,7 +45,8 @@ SEARCH_ENGINE_OPTIONS = {
                                           "pw_launch_kwargs")
 }
 """Supported search engines"""
-_DEFAULT_SE = ("PlaywrightGoogleLinkSearch", )
+_DEFAULT_SE = ("PlaywrightGoogleLinkSearch", "PlaywrightDuckDuckGoLinkSearch",
+               "APIDuckDuckGoSearch")
 
 
 async def web_search_links_as_docs(queries, search_engines=_DEFAULT_SE,

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""ELM Web Scraping - functions to run a search"""
+import pprint
+import asyncio
+import logging
+from collections import namedtuple
+from itertools import zip_longest, chain
+from contextlib import AsyncExitStack
+
+
+from elm.web.file_loader import AsyncFileLoader
+from elm.web.search.bing import PlaywrightBingLinkSearch
+from elm.web.search.duckduckgo import (APIDuckDuckGoSearch,
+                                       PlaywrightDuckDuckGoLinkSearch)
+from elm.web.search.google import (APIGoogleCSESearch, APISerperSearch,
+                                   PlaywrightGoogleCSELinkSearch,
+                                   PlaywrightGoogleLinkSearch)
+from elm.web.search.tavily import APITavilySearch
+from elm.web.search.yahoo import PlaywrightYahooLinkSearch
+from elm.exceptions import ELMKeyError, ELMInputError
+
+
+logger = logging.getLogger(__name__)
+
+
+_RESULTS_PER_QUERY = 10
+_SE_OPT = namedtuple('_SE_OPT', ['se_class', 'uses_browser', 'kwg_key_name'])
+SEARCH_ENGINE_OPTIONS = {
+    "APIDuckDuckGoSearch": _SE_OPT(APIDuckDuckGoSearch, False,
+                                   "ddg_api_kwargs"),
+    "APIGoogleCSESearch": _SE_OPT(APIGoogleCSESearch, False,
+                                  "google_cse_api_kwargs"),
+    "APISerperSearch": _SE_OPT(APISerperSearch, False,
+                               "google_serper_api_kwargs"),
+    "APITavilySearch": _SE_OPT(APITavilySearch, False, "tavily_api_kwargs"),
+    "PlaywrightBingLinkSearch" : _SE_OPT(PlaywrightBingLinkSearch, True,
+                                         "pw_launch_kwargs"),
+    "PlaywrightDuckDuckGoLinkSearch" : _SE_OPT(PlaywrightDuckDuckGoLinkSearch,
+                                               True, "pw_launch_kwargs"),
+    "PlaywrightGoogleCSELinkSearch" : _SE_OPT(PlaywrightGoogleCSELinkSearch,
+                                              True, "pw_launch_kwargs"),
+    "PlaywrightGoogleLinkSearch" : _SE_OPT(PlaywrightGoogleLinkSearch, True,
+                                           "pw_launch_kwargs"),
+    "PlaywrightYahooLinkSearch" : _SE_OPT(PlaywrightYahooLinkSearch, True,
+                                          "pw_launch_kwargs")
+}
+"""Supported search engines"""
+_DEFAULT_SE = ("PlaywrightGoogleLinkSearch", )
+
+
+async def web_search_links_as_docs(queries, search_engines=_DEFAULT_SE,
+                                   num_urls=None, browser_semaphore=None,
+                                   task_name=None, **kwargs):
+    """Retrieve top ``N`` search results as document instances
+
+    Parameters
+    ----------
+    queries : collection of str
+        Collection of strings representing google queries. Documents for
+        the top `num_urls` google search results (from all of these
+        queries _combined_ will be returned from this function.
+    search_engines : iterable of str
+        Ordered collection of search engine names to attempt for web
+        search. If the first search engine in the list returns a set
+        of URLs, then iteration will end and documents for each URL will
+        be returned. Otherwise, the next engine in this list will be
+        used to run the web search. If this also fails, the next engine
+        is used and so on. If all web searched fail, en empty list is
+        returned. See :obj:`~elm.web.search.run.SEARCH_ENGINE_OPTIONS`
+        for supported search engine options.
+        By default, ``("PlaywrightGoogleLinkSearch", )``.
+    num_urls : int, optional
+        Number of unique top Google search result to return as docs. The
+        google search results from all queries are interleaved and the
+        top `num_urls` unique URL's are downloaded as docs. If this
+        number is less than ``len(queries)``, some of your queries may
+        not contribute to the final output. By default, ``None``, which
+        sets ``num_urls = 3 * len(queries)``.
+    browser_semaphore : :class:`asyncio.Semaphore`, optional
+        Semaphore instance that can be used to limit the number of
+        playwright browsers open concurrently. If ``None``, no limits
+        are applied. By default, ``None``.
+    task_name : str, optional
+        Optional task name to use in :func:`asyncio.create_task`.
+        By default, ``None``.
+    **kwargs
+        Keyword-argument pairs to initialize
+        :class:`elm.web.file_loader.AsyncFileLoader` and any of the
+        search engines in the `search_engines` input with. For example,
+        you may specify ``pw_launch_kwargs={"headless": False}`` to
+        have all Playwright-based searches show the browser and _also_
+        specify ``google_serper_api_kwargs={"api_key": "..."}`` to
+        specify the API key for the Google Serper search.
+
+    Returns
+    -------
+    list of :class:`elm.web.document.BaseDocument`
+        List of documents representing the top `num_urls` results from
+        the google searches across all `queries`.
+    """
+    num_urls = num_urls or 3 * len(queries)
+    urls = await _search_with_fallback(search_engines, queries, num_urls,
+                                       browser_sem=browser_semaphore,
+                                       task_name=task_name, kwargs=kwargs)
+    logger.debug("Downloading documents for URLS: \n\t-%s", "\n\t-".join(urls))
+    docs = await _load_docs(urls, browser_semaphore, **kwargs)
+    return docs
+
+
+async def _search_with_fallback(search_engines, queries, num_urls,
+                                browser_sem, task_name, kwargs):
+    """Search for links using multiple search engines if needed"""
+    if len(search_engines) < 1:
+        msg = f"Must provide at least one search engine! Got {search_engines=}"
+        logger.error(msg)
+        raise ELMInputError(msg)
+
+    for se_name in search_engines:
+        logger.trace("Searching web using %r", se_name)
+        urls = await _single_se_search(se_name, queries, num_urls,
+                                       browser_sem, task_name, kwargs)
+        if urls:
+            return urls
+
+    logger.warning("No web results found using %d search engines: %r",
+                   len(search_engines), search_engines)
+    return set()
+
+
+async def _single_se_search(se_name, queries, num_urls, browser_sem,
+                            task_name, kwargs):
+    """Search for links using a single search engine"""
+    if se_name not in SEARCH_ENGINE_OPTIONS:
+        msg = (f"'se_name' must be one of: {list(SEARCH_ENGINE_OPTIONS)}\n"
+               f"Got {se_name=}")
+        logger.error(msg)
+        raise ELMKeyError(msg)
+
+    links = await _run_search(se_name, queries, browser_sem, task_name, kwargs)
+    return _down_select_urls(links, num_urls=num_urls)
+
+
+async def _run_search(se_name, queries, browser_sem, task_name, kwargs):
+    """Run a search for multiple queries on a single search engine"""
+    searchers = [asyncio.create_task(_single_query_search(se_name, query,
+                                                          browser_sem, kwargs),
+                                     name=task_name) for query in queries]
+    return await asyncio.gather(*searchers)
+
+
+async def _single_query_search(se_name, query, browser_sem, kwargs):
+    """Execute a single search query on a single search engine"""
+    try:
+        search_engine, uses_browser = _init_se(se_name, kwargs)
+    except Exception as e:
+        logger.error("Could not instantiate %s", se_name)
+        logger.exception(e)
+        return [[]]
+
+    if uses_browser:
+        return await _single_query_pw(search_engine, query,
+                                      browser_sem=browser_sem)
+
+    return await _single_query_api(search_engine, query)
+
+
+async def _single_query_pw(search_engine, question, browser_sem):
+    """Perform a single browser-based search"""
+    if browser_sem is None:
+        browser_sem = AsyncExitStack()
+
+    logger.trace("Single search browser_semaphore=%r", browser_sem)
+    async with browser_sem:
+        logger.trace("Starting %s search for %r with browser_semaphore=%r",
+                     search_engine._SE_NAME, question, browser_sem)
+        return await search_engine.results(question,
+                                           num_results=_RESULTS_PER_QUERY)
+
+
+async def _single_query_api(search_engine, question):
+    """Perform a single api-based search"""
+    logger.trace("Starting %s search for %r", search_engine._SE_NAME, question)
+    return await search_engine.results(question,
+                                       num_results=_RESULTS_PER_QUERY)
+
+
+def _init_se(se_name, kwargs):
+    """Initialize a search engine class"""
+    se_class, uses_browser, kwarg_key = SEARCH_ENGINE_OPTIONS[se_name]
+    if kwarg_key == "pw_launch_kwargs":
+        se_kwargs = kwargs.get(kwarg_key, {})
+    else:
+        se_kwargs = kwargs.pop(kwarg_key, {})
+    return se_class(**se_kwargs), uses_browser
+
+
+def _down_select_urls(search_results, num_urls=5):
+    """Select the top N URLs"""
+    all_urls = chain.from_iterable(zip_longest(*[results[0]
+                                                 for results
+                                                 in search_results]))
+    urls = set()
+    for url in all_urls:
+        if not url:
+            continue
+        urls.add(url)
+        if len(urls) == num_urls:
+            break
+    return urls
+
+
+async def _load_docs(urls, browser_semaphore=None, **kwargs):
+    """Load a document for each input URL"""
+    logger.trace("Downloading docs for the following URL's:\n%r", urls)
+    logger.trace("kwargs for AsyncFileLoader:\n%s",
+                 pprint.PrettyPrinter().pformat(kwargs))
+    file_loader = AsyncFileLoader(browser_semaphore=browser_semaphore,
+                                  **kwargs)
+    docs = await file_loader.fetch_all(*urls)
+
+    page_lens = {doc.metadata.get("source", "Unknown"): len(doc.pages)
+                 for doc in docs}
+    logger.debug("Loaded the following number of pages for docs:\n%s",
+                 pprint.PrettyPrinter().pformat(page_lens))
+    return [doc for doc in docs if not doc.empty]

--- a/elm/web/utilities.py
+++ b/elm/web/utilities.py
@@ -193,11 +193,14 @@ async def pw_page(browser, intercept_routes=False, stealth_config=None):
     browser_type = _BT_RENAME.get(browser.browser_type.name, "random")
 
     logger.trace("Loading browser context for browser type %r", browser_type)
+    ua = UserAgent(browsers=[browser_type],
+                   platforms=["desktop", "mobile"]).random
+    logger.trace("User agent is:\n\t- %s", ua)
     context = await browser.new_context(
         base_url="http://127.0.0.1:443",
         device_scale_factor=uniform(0.8, 1.2),
         extra_http_headers=DEFAULT_HEADERS,
-        user_agent=UserAgent(browsers=[browser_type]).random,
+        user_agent=ua,
         viewport={"width": randint(800, 1400), "height": randint(800, 1400)},
     )
 

--- a/examples/web_scraping_pipeline/example_scrape_wiki.ipynb
+++ b/examples/web_scraping_pipeline/example_scrape_wiki.ipynb
@@ -42,7 +42,12 @@
    "source": [
     "We used only two search queries for this example, but you can use as many as you'd like. Try to differentiate them as much as possible to diversify the set of search results Google returns (while staying as on-topic as possible). What would you type into Google to find an answer to the question you are asking?\n",
     "\n",
-    "Once we have a set of queries we are happy with, we can use the `google_results_as_docs` function in ELM to perform the Google search and return each google search result as an ELM `Document`."
+    "Once we have a set of queries we are happy with, we can use the `web_search_links_as_docs` function in ELM to perform the Google search and return each google search result as an ELM `Document`.\n",
+    "\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Tip:</b> Try adding <code>pw_launch_kwargs={\"headless\": False, \"slow_mo\": 1000}</code> to the call below to visualize the search process\n",
+    "</div>"
    ]
   },
   {
@@ -120,10 +125,10 @@
     }
    ],
    "source": [
-    "from elm.web.search.google import google_results_as_docs\n",
+    "from elm.web.search import web_search_links_as_docs\n",
     "\n",
     "\n",
-    "docs = await google_results_as_docs(QUERIES)"
+    "docs = await web_search_links_as_docs(QUERIES)"
    ]
   },
   {

--- a/examples/web_scraping_pipeline/example_scrape_wiki.ipynb
+++ b/examples/web_scraping_pipeline/example_scrape_wiki.ipynb
@@ -52,91 +52,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Failed to decode PDF content!\n",
-      "poppler error creating document\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 376, in read_pdf\n",
-      "    pages = _load_pdf_possibly_multi_col(pdf_bytes)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/rolson2/GitHub/rolson2/elm/elm/utilities/parse.py\", line 391, in _load_pdf_possibly_multi_col\n",
-      "    pages = pdftotext.PDF(pdf_bytes, physical=True)\n",
-      "            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "pdftotext.Error: poppler error creating document\n",
-      "Found incompatible number of HTML (5) and parsed (6) tables! No replacement performed.\n",
-      "Found incompatible number of HTML (3) and parsed (1) tables! No replacement performed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from elm.web.search import web_search_links_as_docs\n",
     "\n",
-    "\n",
-    "docs = await web_search_links_as_docs(QUERIES)"
+    "docs = await web_search_links_as_docs(\n",
+    "    QUERIES,\n",
+    "    pdf_read_kwargs={\"verbose\": False},\n",
+    "    ignore_url_parts={\"openei.org\"},\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Don't worry about the error messages (if any). The messages are emitted because ELM attempts to download every URL as a PDF. If that is not possible, a message is logged, but ELM falls back on reading HTML from the URL instead (which is probably what you want).\n",
-    "\n",
     "We can check `docs` to see that we indeed got some google search results:"
    ]
   },
@@ -148,12 +80,10 @@
     {
      "data": {
       "text/plain": [
-       "[<elm.web.document.HTMLDocument at 0x138482450>,\n",
-       " <elm.web.document.HTMLDocument at 0x1386a9d10>,\n",
-       " <elm.web.document.HTMLDocument at 0x138d73490>,\n",
-       " <elm.web.document.HTMLDocument at 0x138482910>,\n",
-       " <elm.web.document.HTMLDocument at 0x136255e50>,\n",
-       " <elm.web.document.HTMLDocument at 0x138a07350>]"
+       "[<elm.web.document.HTMLDocument at 0x7f8ce47f7b30>,\n",
+       " <elm.web.document.HTMLDocument at 0x7f8ce4406a20>,\n",
+       " <elm.web.document.HTMLDocument at 0x7f8ce41eb770>,\n",
+       " <elm.web.document.HTMLDocument at 0x7f8ce416a540>]"
       ]
      },
      "execution_count": 3,
@@ -182,12 +112,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'source': 'https://www.nrel.gov/about/'}\n",
-      "{'source': 'https://en.wikipedia.org/wiki/National_Renewable_Energy_Laboratory'}\n",
-      "{'source': 'https://www.nrel.gov/about/leadership.html'}\n",
-      "{'source': 'https://en.wikipedia.org/wiki/United_States_Department_of_Energy_National_Laboratories'}\n",
-      "{'source': 'https://openei.org/wiki/NREL'}\n",
-      "{'source': 'https://www.nrel.gov/about/director.html'}\n"
+      "{'source': 'https://en.wikipedia.org/?title=National_Renewable_Energy_Lab&redirect=no'}\n",
+      "{'source': 'https://www.energy.gov/person/dr-martin-keller#:~:text=Martin%20Keller-,Dr.,Alliance%20for%20Sustainable%20Energy%2C%20LLC.'}\n",
+      "{'source': 'https://www2.nrel.gov/about/leadership'}\n",
+      "{'source': 'https://www.linkedin.com/in/martin-keller-a09b016'}\n"
      ]
     }
    ],
@@ -214,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,20 +161,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'source': 'https://en.wikipedia.org/wiki/National_Renewable_Energy_Laboratory'}\n",
-      "{'source': 'https://en.wikipedia.org/wiki/United_States_Department_of_Energy_National_Laboratories'}\n"
+      "{'source': 'https://en.wikipedia.org/wiki/National_Renewable_Energy_Laboratory'}\n"
      ]
     }
    ],
    "source": [
-    "from elm.web.search.google import filter_documents\n",
+    "from elm.web.utilities import filter_documents\n",
     "\n",
     "docs = await filter_documents(docs, url_is_wiki)\n",
     "for d in docs:\n",
@@ -272,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/web/search/test_web_search_run.py
+++ b/tests/web/search/test_web_search_run.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from elm.web.search.run import (_single_se_search, _down_select_urls,
-                                _init_se, _load_docs, _single_se_search)
+                                _init_se, _load_docs)
 from elm.web.search.google import (APIGoogleCSESearch,
                                    PlaywrightGoogleLinkSearch)
 from elm.exceptions import ELMKeyError

--- a/tests/web/search/test_web_search_run.py
+++ b/tests/web/search/test_web_search_run.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""ELM Web searches using search engines tests"""
+from pathlib import Path
+
+import pytest
+
+from elm.web.search.run import (_single_se_search, _down_select_urls,
+                                _init_se, _load_docs, _single_se_search)
+from elm.web.search.google import (APIGoogleCSESearch,
+                                   PlaywrightGoogleLinkSearch)
+from elm.exceptions import ELMKeyError
+
+
+@pytest.mark.asyncio
+async def test_single_se_search_name_dne():
+    """Test error for unknown search engine"""
+    with pytest.raises(ELMKeyError) as err:
+        await _single_se_search("DNE", None, None, None, None, None)
+
+    assert "'se_name' must be one of" in str(err)
+
+
+def test_down_select_urls_empty():
+    """Test down selecting empty list"""
+    assert _down_select_urls([]) == set()
+
+
+def test_down_select_urls_empty_queries():
+    """Test down selecting when all URLs results are empty"""
+    assert _down_select_urls([[[]], [[]]]) == set()
+
+
+def test_down_select_urls_diff_lens():
+    """Test down selecting URLs result lengths differ"""
+    assert _down_select_urls([[['ab']], [['bc', 'cd']]]) == {'ab', 'bc', 'cd'}
+
+
+def test_down_select_urls_one_empty():
+    """Test down selecting URLs when one result is empty"""
+    assert _down_select_urls([[[]], [['bc', 'cd']]]) == {'bc', 'cd'}
+
+
+def test_init_se():
+    """Test initializing a playwright search engine"""
+    test_kwargs = {"pw_launch_kwargs": {"test": 1}}
+    se, *__ = _init_se("PlaywrightGoogleLinkSearch", test_kwargs)
+    assert isinstance(se, PlaywrightGoogleLinkSearch)
+    assert se.launch_kwargs == {"test": 1}
+    assert test_kwargs == {"pw_launch_kwargs": {"test": 1}}
+
+
+def test_init_se_pop_kwargs():
+    """Test that kwargs are correctly popped in func"""
+    test_kwargs = {"pw_launch_kwargs": {"test": 1},
+                   "google_cse_api_kwargs": {"api_key": "test_key"}}
+
+    se, *__ = _init_se("APIGoogleCSESearch", test_kwargs)
+    assert isinstance(se, APIGoogleCSESearch)
+    assert se.api_key == "test_key"
+    assert test_kwargs == {"pw_launch_kwargs": {"test": 1}}
+
+
+@pytest.mark.asyncio
+async def test_load_docs_empty():
+    """Test loading docs for no URLs"""
+    assert await _load_docs(set()) == []
+
+
+@pytest.mark.asyncio
+async def test_single_se_search_bad_build():
+    """Test that bad init of SE gives no results"""
+    test_kwargs = {"google_cse_api_kwargs": {"dne_arg": "test_key"}}
+    results = await _single_se_search("APIGoogleCSESearch", [""], None, None,
+                                      None, test_kwargs)
+    assert results == set()
+
+
+if __name__ == "__main__":
+    pytest.main(["-q", "--show-capture=all", Path(__file__), "-rapP"])


### PR DESCRIPTION
Refactor search to allow falling back to other SE options if initial (likely Google) search fails. The fallback list/order of search engines is entirely configurable by the user (as an input to the search function). 

Also added an option to blacklist URL parts. This can be useful to further customize the web search piece