### PR TITLE
Remove hover when running headless

### DIFF
--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"

--- a/elm/web/search/base.py
+++ b/elm/web/search/base.py
@@ -155,10 +155,6 @@ class PlaywrightSearchEngineLinkSearch(SearchEngineLinkSearch):
         """Extract links for top `num_results` on page"""
         links = await asyncio.to_thread(page.locator, self._SE_SR_TAG)
 
-        if not self.launch_kwargs.get("headless", True):
-            # Viz purposes only
-            [await links.nth(i).hover() for i in range(num_results)]
-
         return [await links.nth(i).get_attribute("href")
                 for i in range(num_results)]
 


### PR DESCRIPTION
I added the hover because it was a nice visualization for the software pulling links. However, Reid and I found that the hover code completely fails in some cases. Moreover, I have a suspicion that it might be triggering bot detection. This PR removes the superfluous behavior.