### PR TITLE
DDG API search updates

### DIFF
--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/elm/web/search/duckduckgo.py
+++ b/elm/web/search/duckduckgo.py
@@ -75,6 +75,10 @@ class APIDuckDuckGoSearch(SearchEngineLinkSearch):
     async def _search(self, query, num_results=10):
         """Search web for links related to a query"""
 
-        results = DDGS().text(query, max_results=num_results, backend="html")
+        ddgs = DDGS(timeout=self.timeout, verify=self.verify)
+        results = ddgs.text(query, region=self.region,
+                            backend=self.backend,
+                            max_results=num_results)
+
         return list(filter(None, (info.get('href', "").replace("+", "%20")
                                   for info in results)))

--- a/elm/web/search/duckduckgo.py
+++ b/elm/web/search/duckduckgo.py
@@ -36,6 +36,42 @@ class APIDuckDuckGoSearch(SearchEngineLinkSearch):
 
     _SE_NAME = "DuckDuckGo API"
 
+    def __init__(self, region="wt-wt", backend="auto", timeout=10,
+                 verify=True, sleep_min_seconds=10, sleep_max_seconds=20):
+        """
+
+        Parameters
+        ----------
+        region : str, optional
+            DDG search region param. By default, ``"wt-wt"``, which
+            signifies no region.
+        backend : {auto, html, lite}, optional
+            Option for DDG search type.
+
+                - auto: select randomly between HTML and Lite backends
+                - html: collect data from https://html.duckduckgo.com
+                - lite: collect data from https://lite.duckduckgo.com
+
+            By default, ``"auto"``.
+        timeout : int, optional
+            Timeout for HTTP requests, in seconds. By default, ``10``.
+        verify : bool, optional
+            Apply SSL verification when making the request.
+            By default, ``True``.
+        sleep_min_seconds : int, optional
+            Minimum number of seconds to sleep between queries.
+            By default, ``10``.
+        sleep_max_seconds : int, optional
+            Maximum number of seconds to sleep between queries.
+            By default, ``20``.
+        """
+        self.region = region
+        self.backend = backend
+        self.timeout = timeout
+        self.verify = verify
+        self.sleep_min_seconds = sleep_min_seconds
+        self.sleep_max_seconds = sleep_max_seconds
+
     async def _search(self, query, num_results=10):
         """Search web for links related to a query"""
 

--- a/elm/web/search/duckduckgo.py
+++ b/elm/web/search/duckduckgo.py
@@ -64,7 +64,9 @@ class APIDuckDuckGoSearch(SearchEngineLinkSearch):
             Apply SSL verification when making the request.
             By default, ``True``.
         sleep_min_seconds : int, optional
-            Minimum number of seconds to sleep between queries.
+            Minimum number of seconds to sleep between queries. We
+            recommend not setting this below ``5`` seconds to avoid
+            rate limiting errors thrown by DuckDuckGo.
             By default, ``10``.
         sleep_max_seconds : int, optional
             Maximum number of seconds to sleep between queries.

--- a/elm/web/search/duckduckgo.py
+++ b/elm/web/search/duckduckgo.py
@@ -5,7 +5,7 @@ import logging
 from duckduckgo_search import DDGS
 
 from elm.web.search.base import (PlaywrightSearchEngineLinkSearch,
-                                 APISearchEngineLinkSearch)
+                                 SearchEngineLinkSearch)
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class PlaywrightDuckDuckGoLinkSearch(PlaywrightSearchEngineLinkSearch):
         await page.keyboard.press('Enter')
 
 
-class APIDuckDuckGoSearch(APISearchEngineLinkSearch):
+class APIDuckDuckGoSearch(SearchEngineLinkSearch):
     """Search the web for links using the DuckDuckGo API"""
 
     _SE_NAME = "DuckDuckGo API"


### PR DESCRIPTION
Thanks to @rolson2 for finding out that DDG API rate limit errors can mostly be avoided by introducing a small delay between queries. In this PR, we allow the user to specify the min/max sleep duration between queries when initiating the class. This may help alleviate some rate limit errors we are currently seeing in the API DDG search