### PR TITLE
Better empty doc logic

### DIFF
--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"

--- a/elm/web/document.py
+++ b/elm/web/document.py
@@ -324,5 +324,6 @@ class HTMLDocument(BaseDocument):
 
 def _non_empty_pages(pages):
     """Return all pages with more than 10 chars"""
-    return filter(lambda page: re.search('[a-zA-Z]', page)
-                               and len(page) > 10, pages)
+    return filter(
+        lambda page: re.search('[a-zA-Z]', page) and len(page) > 10, pages
+    )

--- a/elm/web/document.py
+++ b/elm/web/document.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ELM Web Document class definitions"""
+import re
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import cached_property
@@ -323,4 +324,5 @@ class HTMLDocument(BaseDocument):
 
 def _non_empty_pages(pages):
     """Return all pages with more than 10 chars"""
-    return filter(lambda page: page.isalpha() and len(page) > 10, pages)
+    return filter(lambda page: re.search('[a-zA-Z]', page)
+                               and len(page) > 10, pages)

--- a/elm/web/document.py
+++ b/elm/web/document.py
@@ -77,7 +77,7 @@ class BaseDocument(ABC):
     @property
     def empty(self):
         """bool: ``True`` if the document contains no pages."""
-        return not any(_non_empty_pages(self.pages))
+        return not any(_non_empty_pages(self.text.split("\n")))
 
     @cached_property
     def raw_pages(self):

--- a/elm/web/document.py
+++ b/elm/web/document.py
@@ -76,7 +76,7 @@ class BaseDocument(ABC):
     @property
     def empty(self):
         """bool: ``True`` if the document contains no pages."""
-        return any(_non_empty_pages(self.pages))
+        return not any(_non_empty_pages(self.pages))
 
     @cached_property
     def raw_pages(self):

--- a/elm/web/file_loader.py
+++ b/elm/web/file_loader.py
@@ -197,7 +197,7 @@ class AsyncFileLoader:
 
         logger.trace("Got content from %r", url)
         doc = await self.pdf_read_coroutine(url_bytes, **self.pdf_read_kwargs)
-        if doc.pages:
+        if not doc.empty:
             return doc, url_bytes
 
         logger.trace("PDF read failed; fetching HTML content from %r", url)
@@ -205,7 +205,7 @@ class AsyncFileLoader:
                                        timeout=self.PAGE_LOAD_TIMEOUT,
                                        **self.pw_launch_kwargs)
         doc = await self.html_read_coroutine(text, **self.html_read_kwargs)
-        if doc.pages:
+        if not doc.empty:
             return doc, doc.text
 
         if self.pdf_ocr_read_coroutine:

--- a/tests/web/search/test_web_search.py
+++ b/tests/web/search/test_web_search.py
@@ -14,16 +14,13 @@ import elm.web.search.duckduckgo
 import elm.web.search.bing
 import elm.web.search.yahoo
 
-SE_TO_TEST = [(elm.web.search.duckduckgo.PlaywrightDuckDuckGoLinkSearch, {}),
+SE_TO_TEST = [(elm.web.search.google.PlaywrightGoogleLinkSearch, {})
+              (elm.web.search.duckduckgo.PlaywrightDuckDuckGoLinkSearch, {}),
               (elm.web.search.bing.PlaywrightBingLinkSearch, {}),
               (elm.web.search.yahoo.PlaywrightYahooLinkSearch, {})]
 if CSE_ID := os.getenv("GOOGLE_CSE_ID"):
     SE_TO_TEST.append((elm.web.search.google.PlaywrightGoogleCSELinkSearch,
                        {"cse_url": f"https://cse.google.com/cse?cx={CSE_ID}"}))
-
-if os.getenv("GITHUB_ACTIONS") != "true":
-    # Google link searches fail in GHA for some reason (but not locally)
-    SE_TO_TEST.append((elm.web.search.google.PlaywrightGoogleLinkSearch, {}))
 
 
 @flaky(max_runs=3, min_passes=1)

--- a/tests/web/search/test_web_search.py
+++ b/tests/web/search/test_web_search.py
@@ -14,7 +14,7 @@ import elm.web.search.duckduckgo
 import elm.web.search.bing
 import elm.web.search.yahoo
 
-SE_TO_TEST = [(elm.web.search.google.PlaywrightGoogleLinkSearch, {})
+SE_TO_TEST = [(elm.web.search.google.PlaywrightGoogleLinkSearch, {}),
               (elm.web.search.duckduckgo.PlaywrightDuckDuckGoLinkSearch, {}),
               (elm.web.search.bing.PlaywrightBingLinkSearch, {}),
               (elm.web.search.yahoo.PlaywrightYahooLinkSearch, {})]

--- a/tests/web/search/test_web_search.py
+++ b/tests/web/search/test_web_search.py
@@ -14,13 +14,16 @@ import elm.web.search.duckduckgo
 import elm.web.search.bing
 import elm.web.search.yahoo
 
-SE_TO_TEST = [(elm.web.search.google.PlaywrightGoogleLinkSearch, {}),
-              (elm.web.search.duckduckgo.PlaywrightDuckDuckGoLinkSearch, {}),
+SE_TO_TEST = [(elm.web.search.duckduckgo.PlaywrightDuckDuckGoLinkSearch, {}),
               (elm.web.search.bing.PlaywrightBingLinkSearch, {}),
               (elm.web.search.yahoo.PlaywrightYahooLinkSearch, {})]
 if CSE_ID := os.getenv("GOOGLE_CSE_ID"):
     SE_TO_TEST.append((elm.web.search.google.PlaywrightGoogleCSELinkSearch,
                        {"cse_url": f"https://cse.google.com/cse?cx={CSE_ID}"}))
+
+if os.getenv("GITHUB_ACTIONS") != "true":
+    # Google link searches fail in GHA for some reason (but not locally)
+    SE_TO_TEST.append((elm.web.search.google.PlaywrightGoogleLinkSearch, {}))
 
 
 @flaky(max_runs=3, min_passes=1)

--- a/tests/web/test_osti.py
+++ b/tests/web/test_osti.py
@@ -3,11 +3,19 @@
 Test
 """
 import os
+import time
+import random
 import tempfile
 
 from flaky import flaky
 
 from elm import OstiList
+
+
+def _random_delay(*__):
+    """Randomly sleep for a short time; used for flaky reruns"""
+    time.sleep(random.uniform(0.5, 3.0))
+    return True
 
 
 @flaky(max_runs=5, min_passes=1)
@@ -31,7 +39,7 @@ def test_osti_from_url():
     assert len(docs) == 12
 
 
-@flaky(max_runs=5, min_passes=1)
+@flaky(max_runs=10, min_passes=1, rerun_filter=_random_delay)
 def test_osti_from_oids():
     """Test osti list, make sure we can find specific oids from storage futures
     study"""

--- a/tests/web/test_web_document.py
+++ b/tests/web/test_web_document.py
@@ -118,6 +118,26 @@ def test_doc_repr():
     assert repr(c) == expected_repr
 
 
+@pytest.mark.parametrize("pages", ([], ["aaa"], ["\n\n", "\n", "\r3"]))
+def test_doc_is_empty(pages):
+    """Test that doc without any text returns ``True`` for `empty` property"""
+
+    assert PDFDocument(pages).empty
+    assert HTMLDocument(pages).empty
+
+
+def test_html_string_is_empty_doc():
+    """Test that doc with just html text is empty"""
+
+    html_str = ('<!DOCTYPE html><html><head></head><body style="height: 100%; '
+                'width: 100%; overflow: hidden; margin:0px; background-color: '
+                'rgb(38, 38, 38);"><embed '
+                'name="0AA1AAF79D1EC03DEFB5B45B5529FA56" '
+                'style="position:absolute; left: 0; top: 0;" width="100%" '
+                'height="100%" src="about:blank" type="application/pdf" '
+                'internalid="0AA1AAF79D1EC03DEFB5B45B5529FA56"></body></html>')
+    assert HTMLDocument([html_str]).empty
+
 
 if __name__ == "__main__":
     pytest.main(["-q", "--show-capture=all", Path(__file__), "-rapP"])


### PR DESCRIPTION
HTML-only webpages with no text content would previously still contain a single page with the html; as a string, therefore not being labeled as "empty". In this PR, we update the logic so that documents without any text are labeled as "empty", such that the file loader can try alternative strategies for loading the content