### PR TITLE
More flexible SE input

### DIFF
--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"

--- a/elm/web/file_loader.py
+++ b/elm/web/file_loader.py
@@ -63,6 +63,7 @@ class AsyncFileLoader:
         file_cache_coroutine=None,
         browser_semaphore=None,
         use_scrapling_stealth=False,
+        **__,  # consume any extra kwargs
     ):
         """
 

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -91,9 +91,23 @@ async def web_search_links_as_docs(queries, search_engines=_DEFAULT_SE,
         By default, ``None``.
     **kwargs
         Keyword-argument pairs to initialize
-        :class:`elm.web.file_loader.AsyncFileLoader` and any of the
-        search engines in the `search_engines` input with. For example,
-        you may specify ``pw_launch_kwargs={"headless": False}`` to
+        :class:`elm.web.file_loader.AsyncFileLoader`. This input can
+        also include and any/all of the following keywords:
+
+            - ddg_api_kwargs
+            - google_cse_api_kwargs
+            - google_serper_api_kwargs
+            - tavily_api_kwargs
+            - pw_bing_se_kwargs
+            - pw_ddg_se_kwargs
+            - pw_google_cse_kwargs
+            - pw_google_se_kwargs
+            - pw_yahoo_se_kwargs
+
+        Each of these inputs should be a dictionary with
+        keyword-argument pairs that you can use to initialize the search
+        engines in the `search_engines` input. For example, you may
+        specify ``pw_launch_kwargs={"headless": False}`` to
         have all Playwright-based searches show the browser and _also_
         specify ``google_serper_api_kwargs={"api_key": "..."}`` to
         specify the API key for the Google Serper search.

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -211,11 +211,13 @@ async def _single_query_api(search_engine, question):
 def _init_se(se_name, kwargs):
     """Initialize a search engine class"""
     se_class, uses_browser, kwarg_key = SEARCH_ENGINE_OPTIONS[se_name]
-    if kwarg_key == "pw_launch_kwargs":
-        se_kwargs = kwargs.get(kwarg_key, {})
-    else:
-        se_kwargs = kwargs.pop(kwarg_key, {})
-    return se_class(**se_kwargs), uses_browser
+    init_kwargs = {}
+    if uses_browser:
+        init_kwargs = kwargs.get("pw_launch_kwargs", {})
+
+    init_kwargs.update(kwargs.pop(kwarg_key, {}))
+
+    return se_class(**init_kwargs), uses_browser
 
 
 def _down_select_urls(search_results, num_urls=5, ignore_url_parts=None):

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -34,15 +34,15 @@ SEARCH_ENGINE_OPTIONS = {
                                "google_serper_api_kwargs"),
     "APITavilySearch": _SE_OPT(APITavilySearch, False, "tavily_api_kwargs"),
     "PlaywrightBingLinkSearch": _SE_OPT(PlaywrightBingLinkSearch, True,
-                                        "pw_launch_kwargs"),
+                                        "pw_bing_se_kwargs"),
     "PlaywrightDuckDuckGoLinkSearch": _SE_OPT(PlaywrightDuckDuckGoLinkSearch,
-                                              True, "pw_launch_kwargs"),
+                                              True, "pw_ddg_se_kwargs"),
     "PlaywrightGoogleCSELinkSearch": _SE_OPT(PlaywrightGoogleCSELinkSearch,
-                                             True, "pw_launch_kwargs"),
+                                             True, "pw_google_cse_kwargs"),
     "PlaywrightGoogleLinkSearch": _SE_OPT(PlaywrightGoogleLinkSearch, True,
-                                          "pw_launch_kwargs"),
+                                          "pw_google_se_kwargs"),
     "PlaywrightYahooLinkSearch": _SE_OPT(PlaywrightYahooLinkSearch, True,
-                                         "pw_launch_kwargs")
+                                         "pw_yahoo_se_kwargs")
 }
 """Supported search engines"""
 _DEFAULT_SE = ("PlaywrightGoogleLinkSearch", "PlaywrightDuckDuckGoLinkSearch",

--- a/elm/web/utilities.py
+++ b/elm/web/utilities.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from random import randint, choice
 from contextlib import asynccontextmanager
 
+import httpx
 from slugify import slugify
 from fake_useragent import UserAgent
 from playwright_stealth import stealth_async
@@ -62,6 +63,32 @@ BLOCK_RESOURCE_NAMES = [
     "googletagmanager",
     "lit.connatix",  # <- not sure about this one
 ]
+
+
+async def get_redirected_url(url, **kwargs):
+    """Get the final URL after following redirects.
+
+    Parameters
+    ----------
+    url : str
+        URL to check for redirects.
+    **kwargs
+        Keyword-value arguments to pass to the
+        :class:`httpx.AsyncClient` client.
+
+    Returns
+    -------
+    str
+        The final URL after following redirects, or the original URL if
+        no redirects are found or an error occurs.
+    """
+    kwargs["follow_redirects"] = True
+    try:
+        async with httpx.AsyncClient(**kwargs) as client:
+            response = await client.head(url)
+            return str(response.url)
+    except httpx.RequestError as e:
+        return url
 
 
 def clean_search_query(query):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ duckduckgo-search
 fake_useragent>=2.0.3
 google-api-python-client
 html2text
+httpx
 langchain
 lxml
 matplotlib


### PR DESCRIPTION
Allow uses top pass down init kwargs to each search engine uniquely. Previously, users could only control the pw launch kwargs. Now, each each engine looks for it's own set of kwargs.