### PR TITLE
Fix loss of se kwargs after initial instantiation

### DIFF
--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -215,8 +215,7 @@ def _init_se(se_name, kwargs):
     if uses_browser:
         init_kwargs = kwargs.get("pw_launch_kwargs", {})
 
-    init_kwargs.update(kwargs.pop(kwarg_key, {}))
-
+    init_kwargs.update(kwargs.get(kwarg_key, {}))
     return se_class(**init_kwargs), uses_browser
 
 


### PR DESCRIPTION
The se kwargs were being lost at instantiation in _init_se due to pop. I updated this to use get and now the kwargs seem to be applying for additional instantiations. I've only tested this using 'APIDuckDuckGoSearch'.