### PR TITLE
Add support for SerpAPI

### DIFF
--- a/elm/version.py
+++ b/elm/version.py
@@ -2,4 +2,4 @@
 ELM version number
 """
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"

--- a/elm/web/search/run.py
+++ b/elm/web/search/run.py
@@ -14,6 +14,7 @@ from elm.web.search.duckduckgo import (APIDuckDuckGoSearch,
                                        PlaywrightDuckDuckGoLinkSearch)
 from elm.web.search.dux import DuxDistributedGlobalSearch
 from elm.web.search.google import (APIGoogleCSESearch, APISerperSearch,
+                                   SerpAPIGoogleSearch,
                                    CamoufoxGoogleLinkSearch,
                                    PlaywrightGoogleCSELinkSearch,
                                    PlaywrightGoogleLinkSearch)
@@ -34,6 +35,8 @@ SEARCH_ENGINE_OPTIONS = {
                                   "google_cse_api_kwargs"),
     "APISerperSearch": _SE_OPT(APISerperSearch, False,
                                "google_serper_api_kwargs"),
+    "SerpAPIGoogleSearch": _SE_OPT(SerpAPIGoogleSearch, False,
+                                   "google_serpapi_kwargs"),
     "APITavilySearch": _SE_OPT(APITavilySearch, False, "tavily_api_kwargs"),
     "CamoufoxGoogleLinkSearch": _SE_OPT(CamoufoxGoogleLinkSearch, True,
                                         "cf_google_se_kwargs"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ crawl4ai
 ddgs
 fake_useragent>=2.0.3
 google-api-python-client
+google-search-results
 html2text
 httpx
 langchain


### PR DESCRIPTION
Implementation is very basic and not actually async. May need to add an async implementation in the future. Note, however, that this implementation does make use of SerpAPI's 1 hour cache, which is a nice bonus. It looks like that is not possible (by default anyway) if requesting an async search.